### PR TITLE
Transferred item should only be based on drop callback if it exists

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "red-draggin",
   "main": "red-draggin.js",
-  "version": "2.0.0-5",
+  "version": "2.0.0-6",
   "homepage": "https://github.com/decipherinc/red-draggin",
   "authors": [
     "Christopher Hiller <chiller@decipherinc.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-draggin",
-  "version": "2.0.0-5",
+  "version": "2.0.0-6",
   "description": "Angular directives for sorting nested lists",
   "repository": "https://github.com/decipherinc/red-draggin.git",
   "license": "MIT",

--- a/red-draggin.js
+++ b/red-draggin.js
@@ -451,11 +451,14 @@
               item = rdTransport.item;
               source = rdTransport.container;
 
-              // Invoke the callback, which can transform the transferredObject
-              item = invokeCallback(attr.onDrop, event, item);
+              // Invoke the callback if it exists, which can transform the transferredObject
+              item = attr.onDrop ?
+                invokeCallback(attr.onDrop, event, rdTransport.item) :
+                rdTransport.item;
+              source = rdTransport.container;
 
               // abort the drop if the transferred item tells us to.
-              if (attr.onDrop && !item) {
+              if (!item) {
                 stopDragover(0);
                 return true;
               }


### PR DESCRIPTION
Item was previously getting set to `undefined` if `onDrop` callback did not exist.